### PR TITLE
Fix node version to avoid verbose NPM errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "react-toastify": "4.5.2",
     "tabookey-gasless": "0.4.0-beta2",
     "web3": "1.0.0-beta.37"
+  },
+  "engines": {
+    "node": "10"
   }
 }


### PR DESCRIPTION
# Problem
Currently the node version is not specified neither in the README nor in the package.json
Trying to install everything with node v12 leads to multiple verbose errors that can ruin the plug-and-play experience that should be provided by a demo project

# Proposed solution

Fix the version of node to v10 and enable strict checking, so that running npm install with another node version immediately leads to a clear error that tells the user to use the correct version. 

